### PR TITLE
Allow underscores and slashes in text strings

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -459,7 +459,7 @@ class TextStringObject(utils.string_type, PdfObject):
         else:
             stream.write(b_("("))
             for c in bytearr:
-                if not chr_(c).isalnum() and c != b_(' '):
+                if not chr_(c).isalnum() and c not in b_(' /_'):
                     stream.write(b_("\\%03o" % ord_(c)))
                 else:
                     stream.write(b_(chr_(c)))


### PR DESCRIPTION
Text strings that has anything except A-Z, a-z and 0-9 got scrambled for reasons I don't entirely understand.
This means that "/DA (/Font ..." got the /Font changed to \\057Font, and any form field name with an
underscore would get scrambled. This fixes that.

Closes #425